### PR TITLE
Fix: a bug about updateDoc

### DIFF
--- a/src/components/PomatoFarm.tsx
+++ b/src/components/PomatoFarm.tsx
@@ -71,9 +71,7 @@ export const PomatoFarm = ({ user }: Props) => {
     if(user) {
       const docRef = doc(db, "pomato", user.uid, "records", formattedDate)
       const todayUserPomato = (await getDoc(docRef)).data()
-      
-      console.log(todayUserPomato)
-      
+
       if (todayUserPomato && todayUserPomato.pomodoroCount) {
         setPomatoCount(todayUserPomato.pomodoroCount)
       } else {
@@ -132,8 +130,14 @@ export const PomatoFarm = ({ user }: Props) => {
       try {
         const increasedPomato = pomatoCount + 1
         const docRef = doc(db, "pomato", user.uid, "records", formattedDate)
-        console.log(docRef)
+        const checkDocRef = (await getDoc(docRef)).data()
 
+        checkDocRef ?
+        await updateDoc(docRef, {
+          pomodoroCount: increasedPomato,
+          updatedAt: serverTimestamp(),
+        })
+        :
         await setDoc(docRef, {
           pomodoroCount: increasedPomato,
           createdAt: serverTimestamp(),


### PR DESCRIPTION
# Description
error log said:
<img width="416" height="70" alt="Screenshot 2025-11-15 at 1 54 43 pm" src="https://github.com/user-attachments/assets/2d45cc9f-8a8c-4d66-974c-d53d89d3615a" />

# When does it happen?
- The initial state: If there is no pomodoro data on DB

# Why did it happen?
const docRef = doc(db, "pomato", user.uid, "records", formattedDate)
if (docRef) => updateDoc
else => setDoc

I guess because of this code.
Even though there were no documents on docRef,
docRef seems not to be null or undefined.

# How can I resolve it?
(I think this is not the best way to resolve it, but)
We finish pomodoro -> get docRef.data() of {yyyy-mm-dd] from FireStore -> if it is null, setDoc. else, updateDoc.