### PR TITLE
[WIP]fixing layout

### DIFF
--- a/src/components/page-components/PomatoFarm.tsx
+++ b/src/components/page-components/PomatoFarm.tsx
@@ -171,8 +171,9 @@ export const PomatoFarm = ({ user }: Props) => {
 
   return (
     <Box 
-      gap={4} 
-      padding={4}
+      gap={4}
+      paddingX={4}
+      paddingBottom={4}
       backgroundColor={colors.background.main}
       borderRadius={16}
     >
@@ -186,7 +187,7 @@ export const PomatoFarm = ({ user }: Props) => {
         borderRadius="50%"
         onClick={onClick}
         position="relative"
-        marginBottom={8}
+        marginBottom={4}
       >
         <Text
           fontSize={{ mdTo2xl: 48, base: 24 }}
@@ -261,19 +262,16 @@ export const PomatoFarm = ({ user }: Props) => {
         id="today-record"
         backgroundColor={colors.background.white}
         borderRadius={16}
-        marginTop={8}
+        marginTop={4}
         padding={4}
       >
         <Heading color={colors.text.tomatoGreen}>
-          📝 오늘의 기록
+          📝 TODO App
         </Heading>
         <Box
           id="todays-tomato"
           marginBottom={4}
         >
-          <Text fontWeight={600}>
-          🚜 오늘 수확한 토마토 수
-          </Text>
           <Text>
             {displayPomatoCount(pomatoCount)}
           </Text>
@@ -282,27 +280,6 @@ export const PomatoFarm = ({ user }: Props) => {
           id="todays-tomato"
           marginBottom={4}
         >
-          <Text fontWeight={600}>
-          ⏱️ 오늘 집중 시간
-          </Text>
-          <Text>
-            시간
-          </Text>
-        </Box>        
-        <Box
-          id="todo-list"
-          backgroundColor={colors.background.lightWood}
-          padding={2}
-          borderRadius={8}
-        >
-          <Text fontWeight={600}>
-            ToDo List (자유 기록)
-          </Text>
-          <Box
-            backgroundColor={colors.background.main}
-          >
-            <Text>개발 예정</Text>
-          </Box>
         </Box>
       </Box>
       </Box>

--- a/src/components/page-components/PomatoManage.tsx
+++ b/src/components/page-components/PomatoManage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Tabs } from "@chakra-ui/react"
+import { Text, Box, Tabs } from "@chakra-ui/react"
 import { LuCalendarDays, LuUser } from "react-icons/lu"
 import { colors } from '@/constants/palette'
 
@@ -29,10 +29,14 @@ export const PomatoManage = () => {
           </Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content padding={2} value="daily">
-          일일 수확 관리 (개발 예정)
+          <Text fontWeight={600}>
+            🚜 오늘 수확한 토마토 수
+          </Text>
         </Tabs.Content>
         <Tabs.Content padding={2} value="monthly">
-          달별 관리 (개발 예정)
+          <Text fontWeight={600}>
+            🚜 이번 달 수확한 토마토 수
+          </Text>
         </Tabs.Content>
       </Tabs.Root>
     </Box>

--- a/src/components/shared/PomatoImage.tsx
+++ b/src/components/shared/PomatoImage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Image } from "@chakra-ui/react"
 
-export const PomatoImage = () => <Image borderRadius="50%" src="pomato.png" />
+export const PomatoImage = () => <Image width={{ mdTo2xl: "80%", base: "100%" }} borderRadius="50%" src="pomato.png" />
     
   

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,6 @@ export default function Home() {
         setLoggedUser(user)
       }
     })
-
     return () => unsubscribe()
     }, [router])
 
@@ -36,8 +35,8 @@ export default function Home() {
 
   return (
     <Box
-      marginX={{ mdTo2xl: 8, base: 0 }}
-      paddingX={{ mdTo2xl: 16, base: 4 }}
+      marginX={{ mdTo2xl: 4, base: 0 }}
+      paddingX={{ mdTo2xl: 8, base: 4 }}
       paddingY={{ mdTo2xl: 8, base: 4 }}
     >
       <UserInfo user={loggedUser} />
@@ -50,7 +49,7 @@ export default function Home() {
       >
         <Heading
           textAlign="center"
-          fontSize={42}
+          fontSize={36}
           color={colors.primary.main}
         >
           🌱 Pomato Farm


### PR DESCRIPTION
# 개요(Summary)
- Layout 일관성 개선

# AS-IS
- 지금 레이아웃의 의도가 불분명하기 때문에, Task 관리 영역과 피드백 구간이 일관성을 가지도록 개선함.
<img width="1302" height="745" alt="image" src="https://github.com/user-attachments/assets/95841939-de7c-42d6-9a7c-f80507e11d0d" />

# To-be
- 왼쪽 영역: 생산성 관리 / 오른쪽 영역: 결과 피드백 및 확인
<img width="1512" height="982" alt="Layout 설계 - PC" src="https://github.com/user-attachments/assets/fc6d4adf-bfc3-40ed-ba2a-85f3678eda33" />